### PR TITLE
fixed rumble running after being disconnected

### DIFF
--- a/sixad/sixad-sixaxis.cpp
+++ b/sixad/sixad-sixaxis.cpp
@@ -354,7 +354,6 @@ int main(int argc, char *argv[])
 
     delete ufd;
 
-    do_rumble(csk, 10, 0xff, 0xff, 0x01);
 
     shutdown(isk, SHUT_RDWR);
     shutdown(csk, SHUT_RDWR);


### PR DESCRIPTION
I've removed the last rumble on disconnect, some fake ps3 controllers which this fork has support started to rumble a long time after being disconnected.